### PR TITLE
Add simplified Chinese localization, add .gitignore, some small fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,157 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# Our custom stuff
+corpus/
+assets/cfg.yaml

--- a/assets/cfg.yaml
+++ b/assets/cfg.yaml
@@ -1,2 +1,0 @@
-disp_lang: en_US
-whisper_model: medium

--- a/assets/lang.yaml
+++ b/assets/lang.yaml
@@ -23,7 +23,7 @@ en_US:
   # settings:
   disp_lang: 'Display Language'
   wh_model: 'Whisper Model'
-jp_JP:
+ja_JP:
   lang_code: '日本語'
   app_ttl: 'SVSベースラベル作成ツール'
   tab_ttl_1: '転写'
@@ -45,12 +45,12 @@ jp_JP:
   # settings:
   disp_lang: '表示言語'
   wh_model: 'Whisperモデル'
-zh_ZH:
+zh_Hant:
   # translation by ArchiVoice
   lang_code: '中文 (繁體)'
   app_ttl: 'SVS 標註生成工具'
-  tab_ttl_1: '標註'
-  tab_ttl_2: '轉錄'
+  tab_ttl_1: '轉錄'
+  tab_ttl_2: '標註'
   tab_ttl_3: '設定'
   copyright: '© tigermeat 2023'
 
@@ -67,6 +67,29 @@ zh_ZH:
 
   # settings:
   disp_lang: '顯示語言'
+  wh_model: 'Whisper模型'
+zh_Hans:
+  # translation by oxygen-dioxide
+  lang_code: '中文 (简体)'
+  app_ttl: 'SVS 标注生成工具'
+  tab_ttl_1: '转录'
+  tab_ttl_2: '标注'
+  tab_ttl_3: '设置'
+  copyright: '© tigermeat 2023'
+
+  #transcription window strings:
+  corpus_folder: '数据集位置:'
+  open: '打开'
+  lang_choice: '转录语言'
+  run_trns: '运行转录'
+
+  # aligner window strings:
+  model_lbl: '选择 SOFA 模型:'
+  op_lbl: '选择输出格式:'
+  run_align: '运行 SOFA'
+
+  # settings:
+  disp_lang: '显示语言'
   wh_model: 'Whisper模型'
 id_ID:
   # translation by Koji

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-openvpi-whisper
+openai-whisper
 customtkinter
 ftfy
 pykakasi

--- a/sofa_gui.py
+++ b/sofa_gui.py
@@ -42,6 +42,7 @@ class App(ctk.CTk):
 					self.cfg.update(yaml.safe_load(c))
 				except yaml.YAMLError as exc:
 					print(exc)
+			c.close()
 
 		# should this be a StringVar? :thonking:
 		self.clang = ctk.StringVar(value=self.cfg['disp_lang'])

--- a/sofa_gui.py
+++ b/sofa_gui.py
@@ -30,13 +30,18 @@ class App(ctk.CTk):
 
 		# non GUI config stuff
 		# define and load strings
-		self.cfg = {}
-		with open('assets/cfg.yaml', 'r', encoding='utf-8') as c:
-			try:
-				self.cfg = yaml.safe_load(c)
-			except yaml.YAMLError as exc:
-				print(exc)
-			c.close()
+
+		#Default config
+		self.cfg = {
+			'disp_lang': 'en_US',
+			'whisper_model': 'medium'
+		}
+		if(pathlib.Path('assets/cfg.yaml').exists()):
+			with open('assets/cfg.yaml', 'r', encoding='utf-8') as c:
+				try:
+					self.cfg.update(yaml.safe_load(c))
+				except yaml.YAMLError as exc:
+					print(exc)
 
 		# should this be a StringVar? :thonking:
 		self.clang = ctk.StringVar(value=self.cfg['disp_lang'])
@@ -89,6 +94,17 @@ class App(ctk.CTk):
 				os.startfile(filename)
 			except:
 				subprocess.Popen(['xdg-open', filename])
+		
+		def startfolder(self, foldername):
+			"""
+			Open a folder in file explorer
+			If the folder doesn't exist, create it.
+			"""
+			folder = pathlib.Path(foldername)
+			#create the folder if it doesn't exist
+			if(not folder.is_dir()):
+				folder.mkdir()
+			startfile(self, folder)
 
 		def update_wh_model(self):
 			self.inf_wh_model.set(self.set_wh_cmbo.get())
@@ -144,7 +160,7 @@ class App(ctk.CTk):
 
 		self.corp_btn = ctk.CTkButton(self.tabs.tab(self.tab_ttl_1),
 									  text=fxy(self._l[self.clang.get()]['open']),
-									  command=lambda: startfile(self, 'corpus'))
+									  command=lambda: startfolder(self, 'corpus'))
 		self.corp_btn.grid(row=0, column=1, padx=5, pady=5, sticky=tk.N)
 
 		# what lang are you transcribing?


### PR DESCRIPTION
- Add simplified Chinese localization, fix culture codes. The culture code for traditional and simplified Chinese are zh-Hant and zh-Hans. The culture code for Japanese is ja-JP. See [microsoft documentation](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-lcid/a9eac961-e77d-41a6-90a5-ce1a8b0cdb9c)
- Add .gitignore
- Remove cfg.yaml from the code repo and add it into .gitignore, because other contributors probably want to change this file for their own use, without pushing their changes into the git repo. The file will be generated when the user launches LabelMakr for the first time.
- Create the corpus folder if it doesn't exist
- Fix requirements.txt. The packagename of whisper should be `openai-whisper`